### PR TITLE
[#40] エラーハンドリング基盤の実装

### DIFF
--- a/backend/src/domain/types/errors.test.ts
+++ b/backend/src/domain/types/errors.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MatchingError,
+  MessageError,
+  ReportError,
+  RoomError,
+  SessionError,
+  toErrorContext,
+} from './errors';
+
+describe('MatchingError', () => {
+  it('code と message を保持する', () => {
+    const error = new MatchingError('QUEUE_ERROR', 'キュー操作に失敗しました');
+    expect(error.code).toBe('QUEUE_ERROR');
+    expect(error.message).toBe('キュー操作に失敗しました');
+    expect(error.name).toBe('MatchingError');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it.each(['QUEUE_ERROR', 'ROOM_CREATION_FAILED', 'ALREADY_IN_QUEUE'] as const)(
+    'コード %s を受け付ける',
+    (code) => {
+      const error = new MatchingError(code, 'テスト');
+      expect(error.code).toBe(code);
+    }
+  );
+});
+
+describe('RoomError', () => {
+  it('code と message を保持する', () => {
+    const error = new RoomError('ROOM_NOT_FOUND', 'ルームが見つかりません');
+    expect(error.code).toBe('ROOM_NOT_FOUND');
+    expect(error.message).toBe('ルームが見つかりません');
+    expect(error.name).toBe('RoomError');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it.each(['ROOM_NOT_FOUND', 'ROOM_ALREADY_CLOSED', 'ROOM_DATABASE_ERROR'] as const)(
+    'コード %s を受け付ける',
+    (code) => {
+      const error = new RoomError(code, 'テスト');
+      expect(error.code).toBe(code);
+    }
+  );
+});
+
+describe('MessageError', () => {
+  it('code と message を保持する', () => {
+    const error = new MessageError('MESSAGE_ROOM_NOT_FOUND', 'ルームが見つかりません');
+    expect(error.code).toBe('MESSAGE_ROOM_NOT_FOUND');
+    expect(error.message).toBe('ルームが見つかりません');
+    expect(error.name).toBe('MessageError');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it.each(['MESSAGE_ROOM_NOT_FOUND', 'MESSAGE_ROOM_CLOSED', 'MESSAGE_DATABASE_ERROR'] as const)(
+    'コード %s を受け付ける',
+    (code) => {
+      const error = new MessageError(code, 'テスト');
+      expect(error.code).toBe(code);
+    }
+  );
+});
+
+describe('SessionError', () => {
+  it('code と message を保持する', () => {
+    const error = new SessionError('SESSION_NOT_FOUND', 'セッションが見つかりません');
+    expect(error.code).toBe('SESSION_NOT_FOUND');
+    expect(error.message).toBe('セッションが見つかりません');
+    expect(error.name).toBe('SessionError');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it.each(['SESSION_NOT_FOUND', 'SESSION_EXPIRED', 'SOCKET_ALREADY_BOUND'] as const)(
+    'コード %s を受け付ける',
+    (code) => {
+      const error = new SessionError(code, 'テスト');
+      expect(error.code).toBe(code);
+    }
+  );
+});
+
+describe('ReportError', () => {
+  it('code と message を保持する', () => {
+    const error = new ReportError('REPORT_ROOM_NOT_FOUND', 'ルームが見つかりません');
+    expect(error.code).toBe('REPORT_ROOM_NOT_FOUND');
+    expect(error.message).toBe('ルームが見つかりません');
+    expect(error.name).toBe('ReportError');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it.each(['REPORT_ROOM_NOT_FOUND', 'ALREADY_REPORTED', 'REPORT_DATABASE_ERROR'] as const)(
+    'コード %s を受け付ける',
+    (code) => {
+      const error = new ReportError(code, 'テスト');
+      expect(error.code).toBe(code);
+    }
+  );
+});
+
+describe('toErrorContext', () => {
+  it('TRANSIENT カテゴリのエラーを変換する', () => {
+    const error = new MatchingError('QUEUE_ERROR', 'キュー操作に失敗しました');
+    const context = toErrorContext(error, 'trace-123');
+
+    expect(context).toStrictEqual({
+      category: 'TRANSIENT',
+      code: 'QUEUE_ERROR',
+      message: 'キュー操作に失敗しました',
+      userMessage: 'エラーが発生しました。しばらくしてからお試しください。',
+      retryable: true,
+      traceId: 'trace-123',
+    });
+  });
+
+  it('BUSINESS_LOGIC カテゴリのエラーを変換する', () => {
+    const error = new MatchingError('ALREADY_IN_QUEUE', 'すでにキューに入っています');
+    const context = toErrorContext(error, 'trace-456');
+
+    expect(context.category).toBe('BUSINESS_LOGIC');
+    expect(context.retryable).toBe(false);
+  });
+
+  it('FATAL カテゴリのエラーを変換する', () => {
+    const error = new RoomError('ROOM_DATABASE_ERROR', 'DB接続エラー');
+    const context = toErrorContext(error, 'trace-789');
+
+    expect(context.category).toBe('FATAL');
+    expect(context.retryable).toBe(false);
+  });
+
+  it('RoomError ROOM_NOT_FOUND は BUSINESS_LOGIC', () => {
+    const error = new RoomError('ROOM_NOT_FOUND', 'ルームが見つかりません');
+    const context = toErrorContext(error, 'trace-001');
+
+    expect(context.category).toBe('BUSINESS_LOGIC');
+    expect(context.retryable).toBe(false);
+  });
+
+  it('RoomError ROOM_ALREADY_CLOSED は BUSINESS_LOGIC', () => {
+    const error = new RoomError('ROOM_ALREADY_CLOSED', 'ルームは既に閉じています');
+    const context = toErrorContext(error, 'trace-002');
+
+    expect(context.category).toBe('BUSINESS_LOGIC');
+    expect(context.retryable).toBe(false);
+  });
+
+  it('MessageError の各コードを正しく変換する', () => {
+    expect(toErrorContext(new MessageError('MESSAGE_ROOM_NOT_FOUND', 'x'), 't').category).toBe(
+      'BUSINESS_LOGIC'
+    );
+    expect(toErrorContext(new MessageError('MESSAGE_ROOM_CLOSED', 'x'), 't').category).toBe(
+      'BUSINESS_LOGIC'
+    );
+    expect(toErrorContext(new MessageError('MESSAGE_DATABASE_ERROR', 'x'), 't').category).toBe(
+      'FATAL'
+    );
+  });
+
+  it('SessionError の各コードを正しく変換する', () => {
+    expect(toErrorContext(new SessionError('SESSION_NOT_FOUND', 'x'), 't').category).toBe(
+      'BUSINESS_LOGIC'
+    );
+    expect(toErrorContext(new SessionError('SESSION_EXPIRED', 'x'), 't').category).toBe(
+      'BUSINESS_LOGIC'
+    );
+    expect(toErrorContext(new SessionError('SOCKET_ALREADY_BOUND', 'x'), 't').category).toBe(
+      'BUSINESS_LOGIC'
+    );
+  });
+
+  it('ReportError の各コードを正しく変換する', () => {
+    expect(toErrorContext(new ReportError('REPORT_ROOM_NOT_FOUND', 'x'), 't').category).toBe(
+      'BUSINESS_LOGIC'
+    );
+    expect(toErrorContext(new ReportError('ALREADY_REPORTED', 'x'), 't').category).toBe(
+      'BUSINESS_LOGIC'
+    );
+    expect(toErrorContext(new ReportError('REPORT_DATABASE_ERROR', 'x'), 't').category).toBe(
+      'FATAL'
+    );
+  });
+});

--- a/backend/src/domain/types/errors.ts
+++ b/backend/src/domain/types/errors.ts
@@ -1,0 +1,89 @@
+// --- エラーコード ---
+export type MatchingErrorCode = 'QUEUE_ERROR' | 'ROOM_CREATION_FAILED' | 'ALREADY_IN_QUEUE';
+export type RoomErrorCode = 'ROOM_NOT_FOUND' | 'ROOM_ALREADY_CLOSED' | 'ROOM_DATABASE_ERROR';
+export type MessageErrorCode =
+  | 'MESSAGE_ROOM_NOT_FOUND'
+  | 'MESSAGE_ROOM_CLOSED'
+  | 'MESSAGE_DATABASE_ERROR';
+export type SessionErrorCode = 'SESSION_NOT_FOUND' | 'SESSION_EXPIRED' | 'SOCKET_ALREADY_BOUND';
+export type ReportErrorCode =
+  | 'REPORT_ROOM_NOT_FOUND'
+  | 'ALREADY_REPORTED'
+  | 'REPORT_DATABASE_ERROR';
+
+// --- ベースエラークラス ---
+class DomainBaseError<C extends string> extends Error {
+  readonly code: C;
+  constructor(code: C, message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+  }
+}
+
+// --- エラークラス ---
+export class MatchingError extends DomainBaseError<MatchingErrorCode> {}
+export class RoomError extends DomainBaseError<RoomErrorCode> {}
+export class MessageError extends DomainBaseError<MessageErrorCode> {}
+export class SessionError extends DomainBaseError<SessionErrorCode> {}
+export class ReportError extends DomainBaseError<ReportErrorCode> {}
+
+// --- DomainError Union型 ---
+export type DomainError =
+  | MatchingError
+  | RoomError
+  | MessageError
+  | SessionError
+  | ReportError;
+
+// --- エラーコンテキスト ---
+export type ErrorCategory = 'TRANSIENT' | 'FATAL' | 'BUSINESS_LOGIC';
+
+export interface ErrorContext {
+  readonly category: ErrorCategory;
+  readonly code: string;
+  readonly message: string;
+  readonly userMessage: string;
+  readonly retryable: boolean;
+  readonly traceId: string;
+}
+
+const TRANSIENT_CODES: ReadonlySet<string> = new Set([
+  'QUEUE_ERROR',
+  'ROOM_CREATION_FAILED',
+]);
+
+const FATAL_CODES: ReadonlySet<string> = new Set([
+  'ROOM_DATABASE_ERROR',
+  'MESSAGE_DATABASE_ERROR',
+  'REPORT_DATABASE_ERROR',
+]);
+
+export function toErrorContext(error: DomainError, traceId: string): ErrorContext {
+  const category = categorize(error.code);
+  return {
+    category,
+    code: error.code,
+    message: error.message,
+    userMessage: userMessageFor(category),
+    retryable: category === 'TRANSIENT',
+    traceId,
+  };
+}
+
+function categorize(code: string): ErrorCategory {
+  if (TRANSIENT_CODES.has(code)) return 'TRANSIENT';
+  if (FATAL_CODES.has(code)) return 'FATAL';
+  return 'BUSINESS_LOGIC';
+}
+
+function userMessageFor(category: ErrorCategory): string {
+  switch (category) {
+    case 'TRANSIENT':
+      return 'エラーが発生しました。しばらくしてからお試しください。';
+    case 'FATAL':
+      return 'システムエラーが発生しました。';
+    case 'BUSINESS_LOGIC':
+      return '操作を完了できませんでした。';
+  }
+}

--- a/backend/src/infrastructure/errorHandler.test.ts
+++ b/backend/src/infrastructure/errorHandler.test.ts
@@ -1,0 +1,104 @@
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MatchingError, RoomError } from '../domain/types/errors';
+import { handleError, retryWithBackoff } from './errorHandler';
+
+describe('handleError', () => {
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('ソケットに error イベントを emit する', () => {
+    const socket = { emit: vi.fn() };
+    const error = new MatchingError('QUEUE_ERROR', 'キュー操作に失敗しました');
+
+    handleError(socket as never, error, 'trace-123');
+
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      code: 'QUEUE_ERROR',
+      message: 'エラーが発生しました。しばらくしてからお試しください。',
+      retryable: true,
+    });
+  });
+
+  it('FATAL エラーの場合 retryable: false で emit する', () => {
+    const socket = { emit: vi.fn() };
+    const error = new RoomError('ROOM_DATABASE_ERROR', 'DB接続エラー');
+
+    handleError(socket as never, error, 'trace-456');
+
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      code: 'ROOM_DATABASE_ERROR',
+      message: 'システムエラーが発生しました。',
+      retryable: false,
+    });
+  });
+
+  it('構造化ログを出力する', () => {
+    const socket = { emit: vi.fn() };
+    const error = new MatchingError('QUEUE_ERROR', 'キュー操作に失敗しました');
+
+    handleError(socket as never, error, 'trace-789');
+
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    const logArg = JSON.parse(consoleErrorSpy.mock.calls[0][0] as string);
+    expect(logArg).toMatchObject({
+      level: 'error',
+      category: 'TRANSIENT',
+      code: 'QUEUE_ERROR',
+      message: 'キュー操作に失敗しました',
+      traceId: 'trace-789',
+    });
+    expect(logArg.timestamp).toBeDefined();
+  });
+});
+
+describe('retryWithBackoff', () => {
+  it('成功時に即座に結果を返す', async () => {
+    const operation = vi.fn().mockResolvedValue('success');
+
+    const result = await retryWithBackoff(operation, 3, 0);
+
+    expect(result).toBe('success');
+    expect(operation).toHaveBeenCalledOnce();
+  });
+
+  it('失敗後にリトライして成功する', async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue('success');
+
+    const result = await retryWithBackoff(operation, 3, 0);
+
+    expect(result).toBe('success');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('最大リトライ回数を超えたらエラーをスローする', async () => {
+    const error = new Error('persistent failure');
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(retryWithBackoff(operation, 2, 0)).rejects.toThrow('persistent failure');
+    expect(operation).toHaveBeenCalledTimes(3); // 初回 + 2リトライ
+  });
+
+  it('デフォルトの baseDelay は 1000ms', async () => {
+    const start = Date.now();
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue('success');
+
+    await retryWithBackoff(operation, 1);
+
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(900); // 1000ms ± tolerance
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/infrastructure/errorHandler.ts
+++ b/backend/src/infrastructure/errorHandler.ts
@@ -1,0 +1,54 @@
+import type { DomainError, ErrorContext } from '../domain/types/errors';
+import { toErrorContext } from '../domain/types/errors';
+
+interface SocketLike {
+  emit(event: string, data: unknown): void;
+}
+
+export function handleError(socket: SocketLike, error: DomainError, traceId: string): void {
+  const context = toErrorContext(error, traceId);
+
+  logStructured(context);
+
+  socket.emit('error', {
+    code: context.code,
+    message: context.userMessage,
+    retryable: context.retryable,
+  });
+}
+
+function logStructured(context: ErrorContext): void {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level: 'error',
+    category: context.category,
+    code: context.code,
+    message: context.message,
+    traceId: context.traceId,
+  };
+  console.error(JSON.stringify(entry));
+}
+
+export async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  maxRetries: number,
+  baseDelay = 1000
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxRetries) {
+        const delay = baseDelay * 2 ** attempt;
+        await sleep(delay);
+      }
+    }
+  }
+  throw lastError;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- ドメイン層に5つのサービス用エラークラス（Matching, Room, Message, Session, Report）と `toErrorContext()` によるエラーカテゴリ分類を追加
- インフラ層に `handleError`（構造化ログ + ソケット通知）と `retryWithBackoff`（指数バックオフリトライ）を追加
- ジェネリックな `DomainBaseError<C>` ベースクラスでボイラープレートを削減

## Test plan
- [x] `errors.test.ts`: 全エラークラスの生成・プロパティ確認（28テスト）
- [x] `errorHandler.test.ts`: handleError のソケット emit・構造化ログ、retryWithBackoff のリトライ動作（7テスト）
- [x] 既存の `valueObjects.test.ts` が壊れていないことを確認（19テスト）

Refs: #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)