### PR TITLE
[#24] SessionManagerのインターフェース定義とインメモリ実装

### DIFF
--- a/backend/src/application/interfaces/sessionManagerInterface.ts
+++ b/backend/src/application/interfaces/sessionManagerInterface.ts
@@ -1,0 +1,11 @@
+import type { Result } from 'neverthrow';
+import type { Session } from '../../domain/entities/session';
+import type { SessionError } from '../../domain/types/errors';
+import type { SessionId, SocketId } from '../../domain/types/valueObjects';
+
+export interface SessionManagerInterface {
+  generateSession(socketId: SocketId): Result<Session, SessionError>;
+  getSession(sessionId: SessionId): Result<Session, SessionError>;
+  invalidateSession(sessionId: SessionId): Result<void, SessionError>;
+  bindSocketToSession(sessionId: SessionId, socketId: SocketId): Result<void, SessionError>;
+}

--- a/backend/src/infrastructure/sessionManager.test.ts
+++ b/backend/src/infrastructure/sessionManager.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { SessionId, SocketId } from '../domain/types/valueObjects';
+import { InMemorySessionManager } from './sessionManager';
+
+describe('InMemorySessionManager', () => {
+  const createManager = () => new InMemorySessionManager();
+  const testSocketId = SocketId('socket-abc-123')._unsafeUnwrap();
+  const anotherSocketId = SocketId('socket-xyz-789')._unsafeUnwrap();
+
+  describe('generateSession', () => {
+    it('セッションを生成できる', () => {
+      const manager = createManager();
+      const result = manager.generateSession(testSocketId);
+
+      expect(result.isOk()).toBe(true);
+      const session = result._unsafeUnwrap();
+      expect(session.sessionId).toBeDefined();
+      expect(session.socketId).toBe(testSocketId);
+      expect(session.createdAt).toBeInstanceOf(Date);
+    });
+
+    it('生成されたSessionIdはUUID v4形式である', () => {
+      const manager = createManager();
+      const session = manager.generateSession(testSocketId)._unsafeUnwrap();
+      const uuidV4Regex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+      expect(uuidV4Regex.test(session.sessionId as string)).toBe(true);
+    });
+
+    it('複数回呼び出すと異なるセッションIDが生成される', () => {
+      const manager = createManager();
+      const session1 = manager.generateSession(testSocketId)._unsafeUnwrap();
+      const session2 = manager.generateSession(anotherSocketId)._unsafeUnwrap();
+
+      expect(session1.sessionId).not.toBe(session2.sessionId);
+    });
+  });
+
+  describe('getSession', () => {
+    it('存在するセッションを取得できる', () => {
+      const manager = createManager();
+      const created = manager.generateSession(testSocketId)._unsafeUnwrap();
+      const result = manager.getSession(created.sessionId);
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap()).toEqual(created);
+    });
+
+    it('存在しないセッションはSESSION_NOT_FOUNDを返す', () => {
+      const manager = createManager();
+      const unknownId = SessionId('00000000-0000-4000-a000-000000000000')._unsafeUnwrap();
+      const result = manager.getSession(unknownId);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('SESSION_NOT_FOUND');
+    });
+  });
+
+  describe('invalidateSession', () => {
+    it('セッションを無効化できる', () => {
+      const manager = createManager();
+      const session = manager.generateSession(testSocketId)._unsafeUnwrap();
+      const result = manager.invalidateSession(session.sessionId);
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('存在しないセッションの無効化はSESSION_NOT_FOUNDを返す', () => {
+      const manager = createManager();
+      const unknownId = SessionId('00000000-0000-4000-a000-000000000000')._unsafeUnwrap();
+      const result = manager.invalidateSession(unknownId);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it('無効化後にgetSessionするとSESSION_NOT_FOUNDを返す', () => {
+      const manager = createManager();
+      const session = manager.generateSession(testSocketId)._unsafeUnwrap();
+      manager.invalidateSession(session.sessionId);
+      const result = manager.getSession(session.sessionId);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('SESSION_NOT_FOUND');
+    });
+  });
+
+  describe('bindSocketToSession', () => {
+    it('新しいSocketIdをバインドできる', () => {
+      const manager = createManager();
+      const session = manager.generateSession(testSocketId)._unsafeUnwrap();
+      const bindResult = manager.bindSocketToSession(session.sessionId, anotherSocketId);
+
+      expect(bindResult.isOk()).toBe(true);
+
+      const updated = manager.getSession(session.sessionId)._unsafeUnwrap();
+      expect(updated.socketId).toBe(anotherSocketId);
+    });
+
+    it('存在しないセッションへのバインドはSESSION_NOT_FOUNDを返す', () => {
+      const manager = createManager();
+      const unknownId = SessionId('00000000-0000-4000-a000-000000000000')._unsafeUnwrap();
+      const result = manager.bindSocketToSession(unknownId, testSocketId);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('SESSION_NOT_FOUND');
+    });
+  });
+});

--- a/backend/src/infrastructure/sessionManager.ts
+++ b/backend/src/infrastructure/sessionManager.ts
@@ -1,0 +1,50 @@
+import crypto from 'node:crypto';
+import { type Result, err, ok } from 'neverthrow';
+import type { SessionManagerInterface } from '../application/interfaces/sessionManagerInterface';
+import { type Session, createSession } from '../domain/entities/session';
+import { SessionError } from '../domain/types/errors';
+import { type SessionId, type SocketId, SessionId as toSessionId } from '../domain/types/valueObjects';
+
+function sessionNotFoundError(): SessionError {
+  return new SessionError('SESSION_NOT_FOUND', 'セッションが見つかりません');
+}
+
+export class InMemorySessionManager implements SessionManagerInterface {
+  private readonly sessions: Map<string, Session> = new Map();
+
+  generateSession(socketId: SocketId): Result<Session, SessionError> {
+    return toSessionId(crypto.randomUUID())
+      .mapErr(() => new SessionError('SESSION_NOT_FOUND', 'セッションIDの生成に失敗しました'))
+      .map((sessionId) => {
+        const session = createSession(sessionId, socketId, new Date());
+        this.sessions.set(sessionId as string, session);
+        return session;
+      });
+  }
+
+  getSession(sessionId: SessionId): Result<Session, SessionError> {
+    const session = this.sessions.get(sessionId as string);
+    if (!session) {
+      return err(sessionNotFoundError());
+    }
+    return ok(session);
+  }
+
+  invalidateSession(sessionId: SessionId): Result<void, SessionError> {
+    if (!this.sessions.has(sessionId as string)) {
+      return err(sessionNotFoundError());
+    }
+    this.sessions.delete(sessionId as string);
+    return ok(undefined);
+  }
+
+  bindSocketToSession(sessionId: SessionId, socketId: SocketId): Result<void, SessionError> {
+    const session = this.sessions.get(sessionId as string);
+    if (!session) {
+      return err(sessionNotFoundError());
+    }
+    const updated: Session = { ...session, socketId };
+    this.sessions.set(sessionId as string, updated);
+    return ok(undefined);
+  }
+}


### PR DESCRIPTION
## 概要
WebSocket接続時のセッション管理基盤として、SessionManagerのインターフェース定義とインメモリ実装を追加する。

## 変更内容
- `SessionManagerInterface` の定義（generateSession / getSession / invalidateSession / bindSocketToSession）
- `InMemorySessionManager` クラスによるインメモリ実装（`Map<string, Session>` で管理）
- 全メソッドの戻り値を `Result` 型に統一し、プロダクションコードでの `_unsafeUnwrap()` 使用を排除
- エラーメッセージの重複を `sessionNotFoundError()` ヘルパーで解消
- 10テストケースによる網羅的なテスト

## テスト
- [x] `pnpm test` 全64テスト通過
- [ ] generateSession: セッション生成、UUID v4形式確認、複数生成で一意性確認
- [ ] getSession: 存在するセッション取得、存在しない → SESSION_NOT_FOUND
- [ ] invalidateSession: 正常無効化、存在しない → SESSION_NOT_FOUND、無効化後に取得不可
- [ ] bindSocketToSession: 正常バインド、存在しない → SESSION_NOT_FOUND

## 関連 Issue
Closes #24

## Insight
- `crypto.randomUUID()` は必ず UUID v4 を返すが、コーディング規約（`_unsafeUnwrap()` はテスト専用）に従い `generateSession` の戻り値を `Result` 型に統一した。これにより全メソッドが一貫した `Result` ベースのAPIとなり、呼び出し側のエラーハンドリングが統一的になる。
- code-reviewer エージェントによるレビューを実施し、規約違反の修正とエラーメッセージの重複解消を反映済み。