### PR TITLE
[#21] MatchingServiceのインターフェース定義とインメモリ実装

### DIFF
--- a/backend/src/application/interfaces/matchingQueueInterface.ts
+++ b/backend/src/application/interfaces/matchingQueueInterface.ts
@@ -1,0 +1,10 @@
+import type { Result } from 'neverthrow';
+import type { MatchingError } from '../../domain/types/errors';
+import type { SessionId } from '../../domain/types/valueObjects';
+
+export interface MatchingQueueInterface {
+  enqueue(sessionId: SessionId): Promise<Result<void, MatchingError>>;
+  dequeue(sessionId: SessionId): Promise<Result<void, MatchingError>>;
+  tryPopPair(): Promise<Result<[SessionId, SessionId] | null, MatchingError>>;
+  includes(sessionId: SessionId): Promise<Result<boolean, MatchingError>>;
+}

--- a/backend/src/application/interfaces/matchingServiceInterface.ts
+++ b/backend/src/application/interfaces/matchingServiceInterface.ts
@@ -1,0 +1,15 @@
+import type { Result } from 'neverthrow';
+import type { MatchingError } from '../../domain/types/errors';
+import type { RoomId, SessionId } from '../../domain/types/valueObjects';
+
+export interface MatchResult {
+  readonly roomId: RoomId;
+  readonly user1SessionId: SessionId;
+  readonly user2SessionId: SessionId;
+}
+
+export interface MatchingServiceInterface {
+  enqueueUser(sessionId: SessionId): Promise<Result<void, MatchingError>>;
+  dequeueUser(sessionId: SessionId): Promise<Result<void, MatchingError>>;
+  tryMatch(): Promise<Result<MatchResult | null, MatchingError>>;
+}

--- a/backend/src/application/interfaces/roomManagerInterface.ts
+++ b/backend/src/application/interfaces/roomManagerInterface.ts
@@ -1,0 +1,10 @@
+import type { Result } from 'neverthrow';
+import type { RoomError } from '../../domain/types/errors';
+import type { RoomId, SessionId } from '../../domain/types/valueObjects';
+
+export interface RoomManagerInterface {
+  createRoom(
+    user1SessionId: SessionId,
+    user2SessionId: SessionId
+  ): Promise<Result<RoomId, RoomError>>;
+}

--- a/backend/src/application/services/matchingService.test.ts
+++ b/backend/src/application/services/matchingService.test.ts
@@ -1,0 +1,134 @@
+import { type Result, err, ok } from 'neverthrow';
+import { describe, expect, it } from 'vitest';
+import { type RoomError, RoomError as RoomErrorClass } from '../../domain/types/errors';
+import { type RoomId, type SessionId, SessionId as toSessionId } from '../../domain/types/valueObjects';
+import { InMemoryMatchingQueue } from '../../infrastructure/matchingQueue';
+import type { RoomManagerInterface } from '../interfaces/roomManagerInterface';
+import { MatchingService } from './matchingService';
+
+const sessionId1 = toSessionId('00000000-0000-4000-a000-000000000001')._unsafeUnwrap();
+const sessionId2 = toSessionId('00000000-0000-4000-a000-000000000002')._unsafeUnwrap();
+const sessionId3 = toSessionId('00000000-0000-4000-a000-000000000003')._unsafeUnwrap();
+const testRoomId = '11111111-1111-4111-a111-111111111111' as RoomId;
+
+function createMockRoomManager(
+  result: Result<RoomId, RoomError> = ok(testRoomId),
+): RoomManagerInterface {
+  return {
+    createRoom: async () => result,
+  };
+}
+
+function createService(roomManager?: RoomManagerInterface) {
+  const queue = new InMemoryMatchingQueue();
+  const service = new MatchingService(queue, roomManager ?? createMockRoomManager());
+  return { queue, service };
+}
+
+describe('MatchingService', () => {
+  describe('enqueueUser', () => {
+    it('ユーザーをキューに追加できる', async () => {
+      const { service } = createService();
+      const result = await service.enqueueUser(sessionId1);
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('同じユーザーを重複追加するとALREADY_IN_QUEUEを返す', async () => {
+      const { service } = createService();
+      await service.enqueueUser(sessionId1);
+      const result = await service.enqueueUser(sessionId1);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('ALREADY_IN_QUEUE');
+    });
+  });
+
+  describe('dequeueUser', () => {
+    it('ユーザーをキューから削除できる', async () => {
+      const { service } = createService();
+      await service.enqueueUser(sessionId1);
+      const result = await service.dequeueUser(sessionId1);
+      expect(result.isOk()).toBe(true);
+    });
+
+    it('存在しないユーザーの削除はQUEUE_ERRORを返す', async () => {
+      const { service } = createService();
+      const result = await service.dequeueUser(sessionId1);
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('QUEUE_ERROR');
+    });
+  });
+
+  describe('tryMatch', () => {
+    it('キューが空の場合はnullを返す', async () => {
+      const { service } = createService();
+      const result = await service.tryMatch();
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap()).toBeNull();
+    });
+
+    it('キューに1人しかいない場合はnullを返す', async () => {
+      const { service } = createService();
+      await service.enqueueUser(sessionId1);
+      const result = await service.tryMatch();
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap()).toBeNull();
+    });
+
+    it('キューに2人いる場合はMatchResultを返す', async () => {
+      const { service } = createService();
+      await service.enqueueUser(sessionId1);
+      await service.enqueueUser(sessionId2);
+      const result = await service.tryMatch();
+
+      expect(result.isOk()).toBe(true);
+      const matchResult = result._unsafeUnwrap();
+      expect(matchResult).not.toBeNull();
+      expect(matchResult?.roomId).toBe(testRoomId);
+      expect(matchResult?.user1SessionId).toBe(sessionId1);
+      expect(matchResult?.user2SessionId).toBe(sessionId2);
+    });
+
+    it('ルーム作成失敗時はROOM_CREATION_FAILEDを返しユーザーをキューに戻す', async () => {
+      const failingRoomManager = createMockRoomManager(
+        err(new RoomErrorClass('ROOM_DATABASE_ERROR', 'DB障害')),
+      );
+      const { service, queue } = createService(failingRoomManager);
+      await service.enqueueUser(sessionId1);
+      await service.enqueueUser(sessionId2);
+
+      const result = await service.tryMatch();
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr().code).toBe('ROOM_CREATION_FAILED');
+
+      // ユーザーがキューに戻されていることを確認
+      const includes1 = await queue.includes(sessionId1);
+      const includes2 = await queue.includes(sessionId2);
+      expect(includes1._unsafeUnwrap()).toBe(true);
+      expect(includes2._unsafeUnwrap()).toBe(true);
+    });
+
+    it('3人以上のキューで先頭2人がマッチされる', async () => {
+      const { service } = createService();
+      await service.enqueueUser(sessionId1);
+      await service.enqueueUser(sessionId2);
+      await service.enqueueUser(sessionId3);
+
+      const result = await service.tryMatch();
+
+      expect(result.isOk()).toBe(true);
+      const matchResult = result._unsafeUnwrap();
+      expect(matchResult?.user1SessionId).toBe(sessionId1);
+      expect(matchResult?.user2SessionId).toBe(sessionId2);
+
+      // 3人目はまだキューにいるのでnullが返る（1人しかいない）
+      const secondResult = await service.tryMatch();
+      expect(secondResult.isOk()).toBe(true);
+      expect(secondResult._unsafeUnwrap()).toBeNull();
+    });
+  });
+});

--- a/backend/src/application/services/matchingService.ts
+++ b/backend/src/application/services/matchingService.ts
@@ -1,0 +1,48 @@
+import { type Result, err, ok } from 'neverthrow';
+import { MatchingError } from '../../domain/types/errors';
+import type { SessionId } from '../../domain/types/valueObjects';
+import type { MatchingQueueInterface } from '../interfaces/matchingQueueInterface';
+import type { MatchResult, MatchingServiceInterface } from '../interfaces/matchingServiceInterface';
+import type { RoomManagerInterface } from '../interfaces/roomManagerInterface';
+
+export class MatchingService implements MatchingServiceInterface {
+  constructor(
+    private readonly queue: MatchingQueueInterface,
+    private readonly roomManager: RoomManagerInterface
+  ) {}
+
+  async enqueueUser(sessionId: SessionId): Promise<Result<void, MatchingError>> {
+    return this.queue.enqueue(sessionId);
+  }
+
+  async dequeueUser(sessionId: SessionId): Promise<Result<void, MatchingError>> {
+    return this.queue.dequeue(sessionId);
+  }
+
+  async tryMatch(): Promise<Result<MatchResult | null, MatchingError>> {
+    const pairResult = await this.queue.tryPopPair();
+    if (pairResult.isErr()) {
+      return err(pairResult.error);
+    }
+
+    const pair = pairResult.value;
+    if (pair === null) {
+      return ok(null);
+    }
+
+    const [user1SessionId, user2SessionId] = pair;
+    const roomResult = await this.roomManager.createRoom(user1SessionId, user2SessionId);
+
+    if (roomResult.isErr()) {
+      await this.queue.enqueue(user1SessionId);
+      await this.queue.enqueue(user2SessionId);
+      return err(new MatchingError('ROOM_CREATION_FAILED', 'ルームの作成に失敗しました'));
+    }
+
+    return ok({
+      roomId: roomResult.value,
+      user1SessionId,
+      user2SessionId,
+    });
+  }
+}

--- a/backend/src/infrastructure/matchingQueue.ts
+++ b/backend/src/infrastructure/matchingQueue.ts
@@ -1,0 +1,38 @@
+import { type Result, err, ok } from 'neverthrow';
+import type { MatchingQueueInterface } from '../application/interfaces/matchingQueueInterface';
+import { MatchingError } from '../domain/types/errors';
+import type { SessionId } from '../domain/types/valueObjects';
+
+export class InMemoryMatchingQueue implements MatchingQueueInterface {
+  private readonly queue: SessionId[] = [];
+
+  async enqueue(sessionId: SessionId): Promise<Result<void, MatchingError>> {
+    if (this.queue.includes(sessionId)) {
+      return err(new MatchingError('ALREADY_IN_QUEUE', '既にマッチング待機中です'));
+    }
+    this.queue.push(sessionId);
+    return ok(undefined);
+  }
+
+  async dequeue(sessionId: SessionId): Promise<Result<void, MatchingError>> {
+    const index = this.queue.indexOf(sessionId);
+    if (index === -1) {
+      return err(new MatchingError('QUEUE_ERROR', 'キューにユーザーが見つかりません'));
+    }
+    this.queue.splice(index, 1);
+    return ok(undefined);
+  }
+
+  async tryPopPair(): Promise<Result<[SessionId, SessionId] | null, MatchingError>> {
+    if (this.queue.length < 2) {
+      return ok(null);
+    }
+    const user1 = this.queue.shift() as SessionId;
+    const user2 = this.queue.shift() as SessionId;
+    return ok([user1, user2]);
+  }
+
+  async includes(sessionId: SessionId): Promise<Result<boolean, MatchingError>> {
+    return ok(this.queue.includes(sessionId));
+  }
+}


### PR DESCRIPTION
## 概要
ユーザーマッチング機能のコアとなる MatchingService を実装。FIFOキューベースで待機ユーザーを管理し、2人をペアリングしてルームを作成する。Redis依存は抽象化し、InMemory実装でテスト可能な設計。

## 変更内容
- `MatchingServiceInterface`: enqueueUser / dequeueUser / tryMatch の3メソッドと `MatchResult` 型を定義
- `MatchingQueueInterface`: Redis キュー操作の抽象化（enqueue / dequeue / tryPopPair / includes）
- `RoomManagerInterface`: #22 に先立ちMatchingServiceが依存する最小インターフェースを先行定義
- `InMemoryMatchingQueue`: SessionId配列によるFIFOキュー実装（重複チェック付き）
- `MatchingService`: キュー操作とRoomManager統合、ルーム作成失敗時のキュー復帰処理
- テスト9ケース: 正常系・異常系・エッジケースを網羅

## テスト
- [x] `pnpm test` 全73テスト合格
- [x] `biome check` フォーマット・リント合格
- [ ] enqueueUser: 正常追加、重複 → ALREADY_IN_QUEUE
- [ ] dequeueUser: 正常削除、存在しない → QUEUE_ERROR
- [ ] tryMatch: 0人/1人 → null、2人 → MatchResult
- [ ] tryMatch: ルーム作成失敗 → ROOM_CREATION_FAILED、キュー復帰
- [ ] tryMatch: 3人以上で先頭2人がマッチ

## 関連 Issue
Closes #21

## Insight
- RoomManagerInterface は #22 の実装に先立ち `createRoom` のみ定義。最小限のインターフェースにすることで、後続Issueでの拡張が容易になる
- MatchingService の `tryMatch` でルーム作成失敗時にユーザーをキューに戻す設計により、一時的な障害でユーザーがマッチング待ちから消えることを防止
- InMemoryMatchingQueue は将来の Redis 実装と同じインターフェースを持つため、差し替えが容易