### PR TITLE
[#9] requestMatchイベントハンドラの実装

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,10 @@
+import type { Server as HttpServer } from 'node:http';
 import { serve } from '@hono/node-server';
+import { createEnqueueUser } from './application/services/enqueueUser';
 import { createHonoServer } from './infrastructure/http/honoServer';
+import { InMemoryMatchingQueue } from './infrastructure/matchingQueue';
+import { InMemorySessionManager } from './infrastructure/sessionManager';
+import { createWebSocketGateway } from './infrastructure/websocket/webSocketGateway';
 
 // 環境変数の読み込み
 const PORT = Number(process.env.PORT) || 3000;
@@ -11,7 +16,7 @@ const app = createHonoServer();
 // サーバーの起動
 console.log(`🚀 Starting server in ${NODE_ENV} mode...`);
 
-serve(
+const httpServer = serve(
   {
     fetch: app.fetch,
     port: PORT,
@@ -19,5 +24,15 @@ serve(
   (info) => {
     console.log(`✅ Server is running on http://localhost:${info.port}`);
     console.log(`📡 Health check: http://localhost:${info.port}/health`);
+    console.log(`🔌 WebSocket: ws://localhost:${info.port}`);
   }
 );
+
+// 依存関係の初期化
+const sessionManager = new InMemorySessionManager();
+const matchingQueue = new InMemoryMatchingQueue();
+const enqueueUser = createEnqueueUser(matchingQueue);
+
+// WebSocket Gatewayの起動
+// @hono/node-server の serve() は HTTP サーバーを返すため HttpServer にキャスト
+createWebSocketGateway(httpServer as HttpServer, sessionManager, enqueueUser);

--- a/backend/src/infrastructure/websocket/webSocketGateway.test.ts
+++ b/backend/src/infrastructure/websocket/webSocketGateway.test.ts
@@ -1,0 +1,152 @@
+import { err, ok } from 'neverthrow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EnqueueUser } from '../../application/interfaces/matchingServiceInterface';
+import type { SessionManagerInterface } from '../../application/interfaces/sessionManagerInterface';
+import type { Session } from '../../domain/entities/session';
+import { MatchingError, SessionError } from '../../domain/types/errors';
+import { SessionId, SocketId } from '../../domain/types/valueObjects';
+import { handleConnection, handleRequestMatch } from './webSocketGateway';
+
+const testSocketId = SocketId('test-socket-id-abc')._unsafeUnwrap();
+const testSessionId = SessionId('00000000-0000-4000-a000-000000000001')._unsafeUnwrap();
+const testSession: Session = {
+  sessionId: testSessionId,
+  socketId: testSocketId,
+  createdAt: new Date(),
+};
+
+function createMockSocket(id = 'test-socket-id-abc') {
+  return {
+    id,
+    data: {} as Record<string, unknown>,
+    emit: vi.fn(),
+    on: vi.fn(),
+    disconnect: vi.fn(),
+  };
+}
+
+describe('handleRequestMatch', () => {
+  it('enqueueUserが成功した場合にwaitingイベントを発行する', async () => {
+    const socket = createMockSocket();
+    const enqueueUser: EnqueueUser = vi.fn().mockResolvedValue(ok(undefined));
+
+    await handleRequestMatch(socket, testSessionId, enqueueUser);
+
+    expect(enqueueUser).toHaveBeenCalledWith(testSessionId);
+    expect(socket.emit).toHaveBeenCalledWith('waiting');
+  });
+
+  it('ALREADY_IN_QUEUEエラーの場合にerrorイベントを発行する', async () => {
+    const socket = createMockSocket();
+    const matchingError = new MatchingError('ALREADY_IN_QUEUE', '既にマッチング待機中です');
+    const enqueueUser: EnqueueUser = vi.fn().mockResolvedValue(err(matchingError));
+
+    await handleRequestMatch(socket, testSessionId, enqueueUser);
+
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      code: 'ALREADY_IN_QUEUE',
+      message: '既にマッチング待機中です',
+    });
+  });
+
+  it('QUEUE_ERRORの場合にerrorイベントを発行する', async () => {
+    const socket = createMockSocket();
+    const matchingError = new MatchingError('QUEUE_ERROR', 'キューエラーが発生しました');
+    const enqueueUser: EnqueueUser = vi.fn().mockResolvedValue(err(matchingError));
+
+    await handleRequestMatch(socket, testSessionId, enqueueUser);
+
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      code: 'QUEUE_ERROR',
+      message: 'キューエラーが発生しました',
+    });
+  });
+});
+
+describe('handleConnection', () => {
+  let sessionManager: SessionManagerInterface;
+  let enqueueUser: EnqueueUser;
+
+  beforeEach(() => {
+    sessionManager = {
+      generateSession: vi.fn().mockReturnValue(ok(testSession)),
+      getSession: vi.fn().mockReturnValue(ok(testSession)),
+      invalidateSession: vi.fn().mockReturnValue(ok(undefined)),
+      bindSocketToSession: vi.fn().mockReturnValue(ok(undefined)),
+    };
+    enqueueUser = vi.fn().mockResolvedValue(ok(undefined));
+  });
+
+  it('接続時にセッションを生成する', () => {
+    const socket = createMockSocket();
+
+    handleConnection(socket, sessionManager, enqueueUser);
+
+    expect(sessionManager.generateSession).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('セッション生成失敗時にerrorイベントを発行してdisconnectする', () => {
+    const socket = createMockSocket();
+    const sessionError = new SessionError('SESSION_NOT_FOUND', 'セッション生成に失敗しました');
+    vi.mocked(sessionManager.generateSession).mockReturnValue(err(sessionError));
+
+    handleConnection(socket, sessionManager, enqueueUser);
+
+    expect(socket.emit).toHaveBeenCalledWith('error', {
+      code: 'SESSION_ERROR',
+      message: 'セッション生成に失敗しました',
+    });
+    expect(socket.disconnect).toHaveBeenCalled();
+  });
+
+  it('requestMatchイベントリスナーを登録する', () => {
+    const socket = createMockSocket();
+
+    handleConnection(socket, sessionManager, enqueueUser);
+
+    const onCalls = vi.mocked(socket.on).mock.calls;
+    const eventNames = onCalls.map(([event]) => event);
+    expect(eventNames).toContain('requestMatch');
+  });
+
+  it('disconnectイベントリスナーを登録する', () => {
+    const socket = createMockSocket();
+
+    handleConnection(socket, sessionManager, enqueueUser);
+
+    const onCalls = vi.mocked(socket.on).mock.calls;
+    const eventNames = onCalls.map(([event]) => event);
+    expect(eventNames).toContain('disconnect');
+  });
+
+  it('disconnect時にセッションを無効化する', () => {
+    const socket = createMockSocket();
+
+    handleConnection(socket, sessionManager, enqueueUser);
+
+    const onCalls = vi.mocked(socket.on).mock.calls;
+    const disconnectCall = onCalls.find(([event]) => event === 'disconnect');
+    expect(disconnectCall).toBeDefined();
+
+    const disconnectHandler = disconnectCall?.[1] as () => void;
+    disconnectHandler();
+
+    expect(sessionManager.invalidateSession).toHaveBeenCalledWith(testSessionId);
+  });
+
+  it('requestMatchイベント受信時にenqueueUserを呼び出しwaitingを発行する', async () => {
+    const socket = createMockSocket();
+
+    handleConnection(socket, sessionManager, enqueueUser);
+
+    const onCalls = vi.mocked(socket.on).mock.calls;
+    const requestMatchCall = onCalls.find(([event]) => event === 'requestMatch');
+    expect(requestMatchCall).toBeDefined();
+
+    const requestMatchHandler = requestMatchCall?.[1] as () => Promise<void>;
+    await requestMatchHandler();
+
+    expect(enqueueUser).toHaveBeenCalledWith(testSessionId);
+    expect(socket.emit).toHaveBeenCalledWith('waiting');
+  });
+});

--- a/backend/src/infrastructure/websocket/webSocketGateway.ts
+++ b/backend/src/infrastructure/websocket/webSocketGateway.ts
@@ -1,0 +1,82 @@
+import type { Server as HttpServer } from 'node:http';
+import { Server } from 'socket.io';
+import type { Socket } from 'socket.io';
+import type { EnqueueUser } from '../../application/interfaces/matchingServiceInterface';
+import type { SessionManagerInterface } from '../../application/interfaces/sessionManagerInterface';
+import type { SessionId } from '../../domain/types/valueObjects';
+import { SocketId } from '../../domain/types/valueObjects';
+
+/**
+ * requestMatchイベントのハンドラ
+ * セッションIDに紐づくユーザーをマッチングキューに追加し、
+ * 成功時はwaitingイベント、失敗時はerrorイベントを発行する
+ */
+export async function handleRequestMatch(
+  socket: Pick<Socket, 'emit'>,
+  sessionId: SessionId,
+  enqueueUser: EnqueueUser
+): Promise<void> {
+  const result = await enqueueUser(sessionId);
+  result.match(
+    () => {
+      socket.emit('waiting');
+    },
+    (error) => {
+      socket.emit('error', { code: error.code, message: error.message });
+    }
+  );
+}
+
+/**
+ * WebSocket接続イベントのハンドラ
+ * 接続時にセッションを生成し、requestMatch・disconnectイベントを登録する
+ */
+export function handleConnection(
+  socket: Pick<Socket, 'id' | 'data' | 'emit' | 'on' | 'disconnect'>,
+  sessionManager: SessionManagerInterface,
+  enqueueUser: EnqueueUser
+): void {
+  const socketIdResult = SocketId(socket.id);
+  if (socketIdResult.isErr()) {
+    socket.emit('error', { code: 'SESSION_ERROR', message: 'セッション生成に失敗しました' });
+    socket.disconnect();
+    return;
+  }
+
+  const sessionResult = sessionManager.generateSession(socketIdResult.value);
+  if (sessionResult.isErr()) {
+    socket.emit('error', { code: 'SESSION_ERROR', message: 'セッション生成に失敗しました' });
+    socket.disconnect();
+    return;
+  }
+
+  const session = sessionResult.value;
+
+  socket.on('requestMatch', async () => {
+    await handleRequestMatch(socket, session.sessionId, enqueueUser);
+  });
+
+  socket.on('disconnect', () => {
+    sessionManager.invalidateSession(session.sessionId);
+  });
+}
+
+/**
+ * WebSocket Gatewayの生成
+ * Socket.IOサーバーを初期化し、接続イベントにハンドラを登録する
+ */
+export function createWebSocketGateway(
+  httpServer: HttpServer,
+  sessionManager: SessionManagerInterface,
+  enqueueUser: EnqueueUser
+): Server {
+  const io = new Server(httpServer, {
+    cors: { origin: '*' },
+  });
+
+  io.on('connection', (socket: Socket) => {
+    handleConnection(socket, sessionManager, enqueueUser);
+  });
+
+  return io;
+}


### PR DESCRIPTION
## 概要

Issue #9 の実装。WebSocket Gateway に `requestMatch` イベントリスナーを追加し、マッチングキューへのエンキューと待機状態通知を実装しました。

## 変更内容

- `backend/src/infrastructure/websocket/webSocketGateway.ts` を新規追加
  - `handleRequestMatch`: `EnqueueUser` を呼び出し、成功時は `waiting`、失敗時は `error` イベントを発行
  - `handleConnection`: 接続時にセッション生成・イベントリスナー登録・切断時セッション無効化
  - `createWebSocketGateway`: Hono の HTTP サーバーに Socket.IO を統合するファクトリ関数
- `backend/src/index.ts` を更新し、Socket.IO Gateway を起動するよう統合

## テスト計画

- [x] `handleRequestMatch` の単体テスト（waiting/error イベント発行）
- [x] `handleConnection` の単体テスト（セッション生成・イベント登録・disconnect 処理）
- [x] TypeScript 型チェック（`tsc --noEmit`）通過
- [x] Biome lint/format 通過
- [x] 全テスト 95件 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)