### PR TITLE
[#29] マッチング待機画面の実装

### DIFF
--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.2.7",
     "jsdom": "^26.0.0",
     "svelte": "^5.49.0",

--- a/frontend/web/src/App.svelte
+++ b/frontend/web/src/App.svelte
@@ -1,1 +1,8 @@
-<h1>ちゃちゃっと</h1>
+<script lang="ts">
+  import MatchingScreen from './components/MatchingScreen.svelte';
+  import { matchingStore } from './lib/stores/matchingStore.svelte';
+</script>
+
+{#if matchingStore.status === 'idle' || matchingStore.status === 'waiting'}
+  <MatchingScreen />
+{/if}

--- a/frontend/web/src/components/MatchingScreen.svelte
+++ b/frontend/web/src/components/MatchingScreen.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { connect, requestMatch } from '../lib/websocket';
+  import { connectionStore } from '../lib/stores/connectionStore.svelte';
+  import { matchingStore } from '../lib/stores/matchingStore.svelte';
+
+  function handleStartMatching() {
+    connect();
+    requestMatch();
+  }
+</script>
+
+<div class="matching-screen">
+  <h1 class="title">ちゃちゃっと</h1>
+
+  {#if matchingStore.status === 'idle'}
+    <button class="start-button" onclick={handleStartMatching}>マッチング開始</button>
+  {/if}
+
+  {#if matchingStore.status === 'waiting'}
+    <div class="waiting">
+      <div class="spinner" aria-hidden="true"></div>
+      <p class="waiting-message">相手を探しています...</p>
+    </div>
+  {/if}
+
+  {#if connectionStore.error}
+    <p class="error-message" role="alert">{connectionStore.error}</p>
+  {/if}
+</div>
+
+<style>
+  .matching-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    gap: 2rem;
+    padding: 1rem;
+  }
+
+  .title {
+    font-size: 2rem;
+    font-weight: bold;
+    color: #333;
+  }
+
+  .start-button {
+    padding: 0.75rem 2rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #fff;
+    background-color: #4f46e5;
+    border: none;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .start-button:hover {
+    background-color: #4338ca;
+  }
+
+  .waiting {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .spinner {
+    width: 3rem;
+    height: 3rem;
+    border: 4px solid #e5e7eb;
+    border-top-color: #4f46e5;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .waiting-message {
+    font-size: 1rem;
+    color: #6b7280;
+  }
+
+  .error-message {
+    color: #dc2626;
+    font-size: 0.875rem;
+  }
+</style>

--- a/frontend/web/src/components/MatchingScreen.test.ts
+++ b/frontend/web/src/components/MatchingScreen.test.ts
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetConnectionStore, setConnected, setError } from '../lib/stores/connectionStore.svelte';
+import { matchingStore, resetMatchingStore, startWaiting } from '../lib/stores/matchingStore.svelte';
+import MatchingScreen from './MatchingScreen.svelte';
+
+vi.mock('../lib/websocket', () => ({
+  connect: vi.fn(),
+  requestMatch: vi.fn(),
+}));
+
+import { connect, requestMatch } from '../lib/websocket';
+
+describe('MatchingScreen', () => {
+  beforeEach(() => {
+    resetMatchingStore();
+    resetConnectionStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('idle 状態', () => {
+    it('マッチング開始ボタンを表示する', () => {
+      render(MatchingScreen);
+
+      expect(screen.getByRole('button', { name: /マッチング開始/ })).toBeInTheDocument();
+    });
+
+    it('待機中インジケーターを表示しない', () => {
+      render(MatchingScreen);
+
+      expect(screen.queryByText(/相手を探しています/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('マッチング開始ボタンクリック', () => {
+    it('connect と requestMatch を呼び出す', async () => {
+      render(MatchingScreen);
+
+      await fireEvent.click(screen.getByRole('button', { name: /マッチング開始/ }));
+
+      expect(connect).toHaveBeenCalledOnce();
+      expect(requestMatch).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('waiting 状態', () => {
+    it('待機中メッセージを表示する', () => {
+      startWaiting();
+      render(MatchingScreen);
+
+      expect(screen.getByText(/相手を探しています/)).toBeInTheDocument();
+    });
+
+    it('マッチング開始ボタンを表示しない', () => {
+      startWaiting();
+      render(MatchingScreen);
+
+      expect(screen.queryByRole('button', { name: /マッチング開始/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('エラー表示', () => {
+    it('エラーメッセージを表示する', () => {
+      setConnected('session-1');
+      setError('接続に失敗しました');
+      render(MatchingScreen);
+
+      expect(screen.getByText(/接続に失敗しました/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/web/src/test-setup.ts
+++ b/frontend/web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/web/vite.config.ts
+++ b/frontend/web/vite.config.ts
@@ -3,8 +3,12 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [svelte()],
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
         version: 5.1.1(svelte@5.51.2)(vite@6.4.1(@types/node@22.19.11)(tsx@4.21.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.2.7
         version: 5.3.1(svelte@5.51.2)(vite@6.4.1(@types/node@22.19.11)(tsx@4.21.0))(vitest@4.0.18(@types/node@22.19.11)(jsdom@26.1.0)(tsx@4.21.0))
@@ -101,6 +104,9 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -977,6 +983,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/svelte-core@1.0.0':
     resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
     engines: {node: '>=16'}
@@ -1113,6 +1123,9 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
@@ -1150,6 +1163,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   drizzle-kit@0.30.6:
     resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
@@ -1343,6 +1359,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   ioredis@5.9.3:
     resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
     engines: {node: '>=12.22.0'}
@@ -1399,6 +1419,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1465,6 +1489,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -1542,6 +1570,10 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   svelte-check@4.4.0:
     resolution: {integrity: sha512-gB3FdEPb8tPO3Y7Dzc6d/Pm/KrXAhK+0Fk+LkcysVtupvAh6Y/IrBCEZNupq57oh0hcwlxCUamu/rq7GtvfSEg==}
@@ -1788,6 +1820,8 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -2310,6 +2344,15 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@testing-library/svelte-core@1.0.0(svelte@5.51.2)':
     dependencies:
       svelte: 5.51.2
@@ -2427,6 +2470,8 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  css.escape@1.5.1: {}
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -2452,6 +2497,8 @@ snapshots:
   devalue@5.6.2: {}
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   drizzle-kit@0.30.6:
     dependencies:
@@ -2678,6 +2725,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  indent-string@4.0.0: {}
+
   ioredis@5.9.3:
     dependencies:
       '@ioredis/commands': 1.5.0
@@ -2751,6 +2800,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  min-indent@1.0.1: {}
+
   mri@1.2.0: {}
 
   ms@2.1.3: {}
@@ -2798,6 +2849,11 @@ snapshots:
   react-is@17.0.2: {}
 
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -2911,6 +2967,10 @@ snapshots:
   standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   svelte-check@4.4.0(picomatch@4.0.3)(svelte@5.51.2)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## 概要

- Issue #29 に対応するマッチング待機画面を実装

## 変更内容

- `MatchingScreen.svelte` コンポーネントを新規作成
  - `idle` 状態: マッチング開始ボタンを表示
  - `waiting` 状態: スピナー + 「相手を探しています...」メッセージを表示
  - エラー発生時: エラーメッセージを表示
- `App.svelte` を更新し `MatchingScreen` を組み込む
- テスト環境を整備（Svelte 5 コンポーネントテスト対応）
  - `@testing-library/jest-dom` を追加
  - `vite.config.ts` に `resolve.conditions: ['browser']` と `setupFiles` を追加

## テスト

- [ ] `pnpm --filter @cha-chat/web test` で全テスト（29件）が通ることを確認
- [ ] マッチング開始ボタンが表示される
- [ ] ボタンクリックで `connect()` + `requestMatch()` が呼ばれる
- [ ] `waiting` 状態でスピナーと待機メッセージが表示される
- [ ] エラーメッセージが表示される

## 関連 Issue

Closes #29