### PR TITLE
[#30] チャット画面の実装

### DIFF
--- a/frontend/web/src/App.svelte
+++ b/frontend/web/src/App.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+  import ChatScreen from './components/ChatScreen.svelte';
   import MatchingScreen from './components/MatchingScreen.svelte';
+  import { chatStore } from './lib/stores/chatStore.svelte';
   import { matchingStore } from './lib/stores/matchingStore.svelte';
 </script>
 
 {#if matchingStore.status === 'idle' || matchingStore.status === 'waiting'}
   <MatchingScreen />
+{:else if chatStore.roomStatus === 'active'}
+  <ChatScreen />
 {/if}

--- a/frontend/web/src/components/ChatScreen.svelte
+++ b/frontend/web/src/components/ChatScreen.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import { sendMessage, leaveRoom } from '../lib/websocket';
+  import { chatStore } from '../lib/stores/chatStore.svelte';
+  import { connectionStore } from '../lib/stores/connectionStore.svelte';
+  import { messageStore } from '../lib/stores/messageStore.svelte';
+
+  let inputText = $state('');
+
+  function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60).toString().padStart(2, '0');
+    const s = (seconds % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
+  }
+
+  function handleSend() {
+    const text = inputText.trim();
+    if (!text || !chatStore.roomId) return;
+    sendMessage(chatStore.roomId, text);
+    inputText = '';
+  }
+
+  function handleLeave() {
+    if (!chatStore.roomId) return;
+    leaveRoom(chatStore.roomId);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  function isOwnMessage(senderSessionId: string): boolean {
+    return senderSessionId === connectionStore.sessionId;
+  }
+</script>
+
+<div class="chat-screen">
+  <header class="header">
+    <span class="timer">{formatTime(chatStore.remainingSeconds)}</span>
+    <button class="leave-button" onclick={handleLeave}>退出</button>
+  </header>
+
+  <ul class="message-list">
+    {#each messageStore.messages as message (message.messageId)}
+      <li class="message-item {isOwnMessage(message.senderSessionId) ? 'own' : 'other'}">
+        <span class="message-text">{message.text}</span>
+      </li>
+    {/each}
+  </ul>
+
+  <div class="input-area">
+    <input
+      class="text-input"
+      type="text"
+      bind:value={inputText}
+      oninput={(e) => { inputText = (e.currentTarget as HTMLInputElement).value; }}
+      onkeydown={handleKeydown}
+      placeholder="メッセージを入力..."
+      aria-label="メッセージ入力"
+    />
+    <button class="send-button" onclick={handleSend}>送信</button>
+  </div>
+</div>
+
+<style>
+  .chat-screen {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1rem;
+    background-color: #4f46e5;
+    color: #fff;
+  }
+
+  .timer {
+    font-size: 1.25rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .leave-button {
+    padding: 0.25rem 0.75rem;
+    font-size: 0.875rem;
+    color: #fff;
+    background-color: transparent;
+    border: 1px solid #fff;
+    border-radius: 0.25rem;
+    cursor: pointer;
+  }
+
+  .leave-button:hover {
+    background-color: rgba(255, 255, 255, 0.15);
+  }
+
+  .message-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+  }
+
+  .message-item {
+    display: flex;
+    max-width: 75%;
+  }
+
+  .message-item.own {
+    align-self: flex-end;
+  }
+
+  .message-item.other {
+    align-self: flex-start;
+  }
+
+  .message-text {
+    padding: 0.5rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.9375rem;
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+
+  .message-item.own .message-text {
+    background-color: #4f46e5;
+    color: #fff;
+    border-bottom-right-radius: 0.25rem;
+  }
+
+  .message-item.other .message-text {
+    background-color: #e5e7eb;
+    color: #111827;
+    border-bottom-left-radius: 0.25rem;
+  }
+
+  .input-area {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-top: 1px solid #e5e7eb;
+    background-color: #fff;
+  }
+
+  .text-input {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    font-size: 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.5rem;
+    outline: none;
+  }
+
+  .text-input:focus {
+    border-color: #4f46e5;
+  }
+
+  .send-button {
+    padding: 0.5rem 1rem;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: #fff;
+    background-color: #4f46e5;
+    border: none;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .send-button:hover {
+    background-color: #4338ca;
+  }
+</style>

--- a/frontend/web/src/components/ChatScreen.test.ts
+++ b/frontend/web/src/components/ChatScreen.test.ts
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetChatStore, chatStore, activate } from '../lib/stores/chatStore.svelte';
+import { resetConnectionStore, setConnected } from '../lib/stores/connectionStore.svelte';
+import { messageStore, clearMessages, addMessage } from '../lib/stores/messageStore.svelte';
+import ChatScreen from './ChatScreen.svelte';
+
+vi.mock('../lib/websocket', () => ({
+  sendMessage: vi.fn(),
+  leaveRoom: vi.fn(),
+  reportContent: vi.fn(),
+}));
+
+import { sendMessage, leaveRoom } from '../lib/websocket';
+
+const MY_SESSION_ID = 'my-session-id';
+const ROOM_ID = 'room-123';
+
+describe('ChatScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChatStore();
+    resetConnectionStore();
+    clearMessages();
+    setConnected(MY_SESSION_ID);
+    activate(ROOM_ID);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('残り時間', () => {
+    it('残り時間を MM:SS 形式で表示する', () => {
+      chatStore.remainingSeconds = 125;
+      render(ChatScreen);
+
+      expect(screen.getByText('02:05')).toBeInTheDocument();
+    });
+
+    it('残り時間が 0 秒のとき 00:00 を表示する', () => {
+      chatStore.remainingSeconds = 0;
+      render(ChatScreen);
+
+      expect(screen.getByText('00:00')).toBeInTheDocument();
+    });
+  });
+
+  describe('メッセージ一覧', () => {
+    it('メッセージテキストを表示する', () => {
+      addMessage({ messageId: 'msg-1', senderSessionId: 'other-session', text: 'こんにちは', createdAt: '2024-01-01T00:00:00Z' });
+      render(ChatScreen);
+
+      expect(screen.getByText('こんにちは')).toBeInTheDocument();
+    });
+
+    it('メッセージがないとき一覧は空', () => {
+      render(ChatScreen);
+
+      expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+    });
+  });
+
+  describe('メッセージ送信', () => {
+    it('入力フィールドと送信ボタンを表示する', () => {
+      render(ChatScreen);
+
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /送信/ })).toBeInTheDocument();
+    });
+
+    it('テキストを入力して送信するとsendMessageが呼ばれる', async () => {
+      render(ChatScreen);
+
+      await fireEvent.input(screen.getByRole('textbox'), { target: { value: 'テストメッセージ' } });
+      await fireEvent.click(screen.getByRole('button', { name: /送信/ }));
+
+      expect(sendMessage).toHaveBeenCalledWith(ROOM_ID, 'テストメッセージ');
+    });
+
+    it('送信後に入力フィールドがクリアされる', async () => {
+      render(ChatScreen);
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+
+      await fireEvent.input(input, { target: { value: 'テスト' } });
+      await fireEvent.click(screen.getByRole('button', { name: /送信/ }));
+
+      expect(input.value).toBe('');
+    });
+
+    it('空テキストでは送信しない', async () => {
+      render(ChatScreen);
+
+      await fireEvent.click(screen.getByRole('button', { name: /送信/ }));
+
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('退出', () => {
+    it('退出ボタンを表示する', () => {
+      render(ChatScreen);
+
+      expect(screen.getByRole('button', { name: /退出/ })).toBeInTheDocument();
+    });
+
+    it('退出ボタンクリックでleaveRoomが呼ばれる', async () => {
+      render(ChatScreen);
+
+      await fireEvent.click(screen.getByRole('button', { name: /退出/ }));
+
+      expect(leaveRoom).toHaveBeenCalledWith(ROOM_ID);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Issue #30 に対応するチャット画面を実装。

## 変更内容

- `ChatScreen.svelte` を新規作成
  - ヘッダーに残り時間（MM:SS形式）と退出ボタン
  - メッセージ一覧（自分のメッセージは右、相手は左に表示）
  - テキスト入力フォームと送信ボタン（空テキストは送信しない、Enterキー対応）
  - 退出ボタンで `leaveRoom()` を呼び出す
- `App.svelte` を更新し `chatStore.roomStatus === 'active'` でチャット画面を表示

## テスト

- [ ] `pnpm --filter @cha-chat/web test` で全テスト（57件）が通ること
- [ ] 残り時間が MM:SS 形式で表示される
- [ ] メッセージが表示される
- [ ] テキスト送信で `sendMessage` が呼ばれる
- [ ] 空テキストでは送信されない
- [ ] 退出ボタンで `leaveRoom` が呼ばれる

## 関連 Issue

Closes #30