### PR TITLE
[#31] チャット終了画面の実装

### DIFF
--- a/frontend/web/src/App.svelte
+++ b/frontend/web/src/App.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import ChatEndScreen from './components/ChatEndScreen.svelte';
   import ChatScreen from './components/ChatScreen.svelte';
   import MatchingScreen from './components/MatchingScreen.svelte';
   import { chatStore } from './lib/stores/chatStore.svelte';
   import { matchingStore } from './lib/stores/matchingStore.svelte';
 </script>
 
-{#if matchingStore.status === 'idle' || matchingStore.status === 'waiting'}
-  <MatchingScreen />
+{#if chatStore.roomStatus === 'closed'}
+  <ChatEndScreen />
 {:else if chatStore.roomStatus === 'active'}
   <ChatScreen />
+{:else}
+  <MatchingScreen />
 {/if}

--- a/frontend/web/src/components/ChatEndScreen.svelte
+++ b/frontend/web/src/components/ChatEndScreen.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { resetChatStore, chatStore } from '../lib/stores/chatStore.svelte';
+  import { clearMessages } from '../lib/stores/messageStore.svelte';
+  import { resetMatchingStore } from '../lib/stores/matchingStore.svelte';
+
+  const CLOSE_REASON_MESSAGES: Record<string, string> = {
+    timeout: '時間切れでチャットが終了しました',
+    user_left: '相手が退出しました',
+    reported: '報告によりチャットが終了しました',
+  };
+
+  function closeReasonMessage(): string {
+    return CLOSE_REASON_MESSAGES[chatStore.closeReason ?? ''] ?? '';
+  }
+
+  function handleNewMatching() {
+    resetChatStore();
+    clearMessages();
+    resetMatchingStore();
+  }
+</script>
+
+<div class="end-screen">
+  <h1 class="title">チャットが終了しました</h1>
+
+  {#if chatStore.closeReason}
+    <p class="reason">{closeReasonMessage()}</p>
+  {/if}
+
+  <button class="new-match-button" onclick={handleNewMatching}>新しいマッチング</button>
+</div>
+
+<style>
+  .end-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    gap: 1.5rem;
+    padding: 1rem;
+    text-align: center;
+  }
+
+  .title {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #111827;
+  }
+
+  .reason {
+    font-size: 1rem;
+    color: #6b7280;
+  }
+
+  .new-match-button {
+    padding: 0.75rem 2rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #fff;
+    background-color: #4f46e5;
+    border: none;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+
+  .new-match-button:hover {
+    background-color: #4338ca;
+  }
+</style>

--- a/frontend/web/src/components/ChatEndScreen.test.ts
+++ b/frontend/web/src/components/ChatEndScreen.test.ts
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { chatStore, close, resetChatStore } from '../lib/stores/chatStore.svelte';
+import { clearMessages } from '../lib/stores/messageStore.svelte';
+import { matchingStore, resetMatchingStore } from '../lib/stores/matchingStore.svelte';
+import ChatEndScreen from './ChatEndScreen.svelte';
+
+vi.mock('../lib/websocket', () => ({
+  connect: vi.fn(),
+  requestMatch: vi.fn(),
+}));
+
+describe('ChatEndScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetChatStore();
+    resetMatchingStore();
+    clearMessages();
+    close('timeout');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('終了メッセージ', () => {
+    it('チャット終了メッセージを表示する', () => {
+      render(ChatEndScreen);
+
+      expect(screen.getByRole('heading', { name: /チャットが終了しました/ })).toBeInTheDocument();
+    });
+  });
+
+  describe('終了理由', () => {
+    it('timeout のとき時間切れメッセージを表示する', () => {
+      chatStore.closeReason = 'timeout';
+      render(ChatEndScreen);
+
+      expect(screen.getByText(/時間切れ/)).toBeInTheDocument();
+    });
+
+    it('user_left のとき相手退出メッセージを表示する', () => {
+      chatStore.closeReason = 'user_left';
+      render(ChatEndScreen);
+
+      expect(screen.getByText(/相手が退出/)).toBeInTheDocument();
+    });
+
+    it('reported のとき報告メッセージを表示する', () => {
+      chatStore.closeReason = 'reported';
+      render(ChatEndScreen);
+
+      expect(screen.getByText(/報告/)).toBeInTheDocument();
+    });
+  });
+
+  describe('新しいマッチング', () => {
+    it('新しいマッチングボタンを表示する', () => {
+      render(ChatEndScreen);
+
+      expect(screen.getByRole('button', { name: /新しいマッチング/ })).toBeInTheDocument();
+    });
+
+    it('ボタンクリックでマッチング状態をリセットしてマッチング待機画面に戻る', async () => {
+      render(ChatEndScreen);
+
+      await fireEvent.click(screen.getByRole('button', { name: /新しいマッチング/ }));
+
+      expect(chatStore.roomStatus).toBe('idle');
+      expect(matchingStore.status).toBe('idle');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Issue #31 に対応するチャット終了画面を実装。

## 変更内容

- `ChatEndScreen.svelte` を新規作成
  - 「チャットが終了しました」タイトル表示
  - 終了理由に応じたメッセージ
    - `timeout` → 時間切れでチャットが終了しました
    - `user_left` → 相手が退出しました
    - `reported` → 報告によりチャットが終了しました
  - 「新しいマッチング」ボタン: `chatStore` / `messageStore` / `matchingStore` をリセットしてマッチング待機画面に戻る
- `App.svelte` を更新し `chatStore.roomStatus === 'closed'` でチャット終了画面を優先表示

## テスト

- [ ] `pnpm --filter @cha-chat/web test` で全テスト（63件）が通ること

## 関連 Issue

Closes #31